### PR TITLE
Feature/#12_経路探索レスポンスに路線名フィールドを追加

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -133,6 +133,10 @@ const docTemplate = `{
                     "type": "string",
                     "example": "2025-05-28T10:01:00+09:00"
                 },
+                "line_name": {
+                    "type": "string",
+                    "example": "JR中央線快速"
+                },
                 "movetype": {
                     "type": "string",
                     "example": "local_train"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -124,6 +124,10 @@
                     "type": "string",
                     "example": "2025-05-28T10:01:00+09:00"
                 },
+                "line_name": {
+                    "type": "string",
+                    "example": "JR中央線快速"
+                },
                 "movetype": {
                     "type": "string",
                     "example": "local_train"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -23,6 +23,9 @@ definitions:
       from_time:
         example: "2025-05-28T10:01:00+09:00"
         type: string
+      line_name:
+        example: JR中央線快速
+        type: string
       movetype:
         example: local_train
         type: string

--- a/internal/domain/model/route.go
+++ b/internal/domain/model/route.go
@@ -14,4 +14,5 @@ type RouteStep struct {
 	Fromtime         string `json:"from_time" example:"2025-05-28T10:01:00+09:00" description:"出発時間"`
 	Totime           string `json:"to_time" example:"2025-05-28T10:13:00+09:00" description:"到着時間"`
 	Movetype         string `json:"movetype" example:"local_train" description:"移動手段"`
+	LineName         string `json:"line_name" example:"JR中央線快速" description:"路線名"`
 }

--- a/internal/infrastructure/repositoryimpl/route_repositry_impl.go
+++ b/internal/infrastructure/repositoryimpl/route_repositry_impl.go
@@ -34,6 +34,7 @@ type navitimeResponse struct {
 			FromTime string `json:"from_time,omitempty"`
 			ToTime   string `json:"to_time,omitempty"`
 			Move     string `json:"move,omitempty"`
+			LineName string `json:"line_name,omitempty"`
 		} `json:"sections"`
 	} `json:"items"`
 }
@@ -121,6 +122,7 @@ func (r *routeRepository) FetchRouteWithNodeid(from, to, datetime string, via []
 					Fromtime:         section.FromTime,
 					Totime:           section.ToTime,
 					Movetype:         section.Move,
+					LineName:         section.LineName,
 				})
 			}
 		}


### PR DESCRIPTION
/routesearchのレスポンスに、路線名を追加した。

{
  "steps": [
    {
      "departure_station": "東京",
      "arrival_station": "新宿",
      "from_time": "2025-05-13T15:02:00+09:00",
      "to_time": "2025-05-13T15:17:00+09:00",
      "movetype": "rapid_train",
      "line_name": "ＪＲ中央線快速"
    }
  ],
  "total_time": 15,
  "total_fare": 210
}